### PR TITLE
Add MovieLens benchmark (#5)

### DIFF
--- a/benchmark/movielens/dataloader.py
+++ b/benchmark/movielens/dataloader.py
@@ -1,0 +1,277 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pyre-unsafe
+
+"""Shared MovieLens downloader and tensor loader for benchmarks."""
+
+from __future__ import annotations
+
+import csv
+import re
+import urllib.error
+import urllib.request
+import zipfile
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+DATASET_URLS = {
+    "ml-latest-small": "https://files.grouplens.org/datasets/movielens/ml-latest-small.zip",
+    "ml-32m": "https://files.grouplens.org/datasets/movielens/ml-32m.zip",
+    "ml-latest": "https://files.grouplens.org/datasets/movielens/ml-latest.zip",
+}
+DEFAULT_DATA_ROOT = Path(__file__).resolve().parents[1] / "data"
+
+FEATURE_GENRE = 1
+FEATURE_YEAR = 2
+FEATURE_TAG = 3
+
+TAG_TOKEN_RE = re.compile(r"[a-z0-9]+")
+YEAR_RE = re.compile(r"\((\d{4})\)\s*$")
+
+
+@dataclass(frozen=True)
+class MovieDocument:
+    movie_id: int
+    title: str
+    genres: tuple[int, ...]
+    year: int | None
+    tags: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class MovieLensCorpus:
+    feature_ids: torch.Tensor
+    feature_offsets: torch.Tensor
+    feature_values: torch.Tensor
+    documents: list[MovieDocument]
+    num_docs: int
+    base_num_docs: int
+    has_tags: bool
+    genre_labels: dict[int, str]
+    tag_labels: dict[int, str]
+    all_genres: list[int]
+    all_years: list[int]
+    all_tags: list[int]
+
+
+def _normalize_tag(raw_tag: str) -> str | None:
+    tokens = TAG_TOKEN_RE.findall(raw_tag.lower())
+    if not tokens:
+        return None
+    return " ".join(tokens)
+
+
+def _extract_year(title: str) -> int | None:
+    match = YEAR_RE.search(title)
+    return int(match.group(1)) if match is not None else None
+
+
+def resolve_dataset_dir(
+    *,
+    dataset_dir: Path | None,
+    data_root: Path,
+    dataset_name: str,
+    download: bool,
+) -> Path:
+    if dataset_dir is not None:
+        resolved_dir = dataset_dir.expanduser().resolve()
+        if not resolved_dir.is_dir():
+            raise FileNotFoundError(f"Dataset directory not found: {resolved_dir}")
+        return resolved_dir
+
+    resolved_root = data_root.expanduser().resolve()
+    resolved_dir = resolved_root / dataset_name
+    if resolved_dir.is_dir():
+        return resolved_dir
+
+    if not download:
+        raise FileNotFoundError(
+            "MovieLens dataset not found. Pass --download or set --dataset-dir."
+        )
+
+    return download_dataset(dataset_name, resolved_root)
+
+
+def download_dataset(dataset_name: str, data_root: Path) -> Path:
+    data_root.mkdir(parents=True, exist_ok=True)
+    dataset_dir = data_root / dataset_name
+    if dataset_dir.is_dir():
+        return dataset_dir
+
+    url = DATASET_URLS[dataset_name]
+    archive_path = data_root / f"{dataset_name}.zip"
+    print(f"Downloading {dataset_name} from {url}")
+    try:
+        urllib.request.urlretrieve(url, archive_path)
+    except urllib.error.URLError as error:
+        raise RuntimeError(
+            "Failed to download MovieLens. Pass --dataset-dir to a local extracted "
+            "MovieLens CSV dataset if download is unavailable."
+        ) from error
+
+    with zipfile.ZipFile(archive_path) as archive:
+        archive.extractall(data_root)
+
+    if not dataset_dir.is_dir():
+        raise FileNotFoundError(
+            f"Expected extracted dataset directory at {dataset_dir}, but it was not created."
+        )
+    return dataset_dir
+
+
+def _load_tag_metadata(
+    tags_path: Path,
+    min_tag_frequency: int,
+    max_tags_per_movie: int,
+) -> dict[int, tuple[str, ...]]:
+    per_movie_tags: dict[int, Counter[str]] = defaultdict(Counter)
+    global_counts: Counter[str] = Counter()
+
+    with tags_path.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            raw_tag = row.get("tag")
+            movie_id = row.get("movieId")
+            if raw_tag is None or movie_id is None:
+                continue
+            tag = _normalize_tag(raw_tag)
+            if tag is None:
+                continue
+            movie_key = int(movie_id)
+            per_movie_tags[movie_key][tag] += 1
+            global_counts[tag] += 1
+
+    allowed_tags = {
+        tag for tag, count in global_counts.items() if count >= min_tag_frequency
+    }
+
+    filtered: dict[int, tuple[str, ...]] = {}
+    for movie_id, counts in per_movie_tags.items():
+        kept = [
+            tag
+            for tag, _ in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+            if tag in allowed_tags
+        ][:max_tags_per_movie]
+        filtered[movie_id] = tuple(kept)
+    return filtered
+
+
+def load_corpus(
+    dataset_dir: Path,
+    *,
+    include_tags: bool,
+    min_tag_frequency: int,
+    max_tags_per_movie: int,
+    max_movies: int | None,
+    replication_factor: int,
+) -> MovieLensCorpus:
+    if replication_factor < 1:
+        raise ValueError("--replication-factor must be >= 1")
+
+    movies_path = dataset_dir / "movies.csv"
+    if not movies_path.is_file():
+        raise FileNotFoundError(
+            f"{dataset_dir} does not look like a CSV MovieLens dataset: missing movies.csv"
+        )
+
+    tag_strings_by_movie: dict[int, tuple[str, ...]] = {}
+    tags_path = dataset_dir / "tags.csv"
+    if include_tags and tags_path.is_file():
+        tag_strings_by_movie = _load_tag_metadata(
+            tags_path,
+            min_tag_frequency=min_tag_frequency,
+            max_tags_per_movie=max_tags_per_movie,
+        )
+
+    raw_movies: list[tuple[int, str, tuple[str, ...], int | None, tuple[str, ...]]] = []
+    all_genres: set[str] = set()
+    all_tags: set[str] = set()
+
+    with movies_path.open("r", newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            movie_id = int(row["movieId"])
+            title = row["title"]
+            genres_raw = row["genres"]
+            genres = (
+                ()
+                if genres_raw == "(no genres listed)"
+                else tuple(sorted(genres_raw.split("|")))
+            )
+            tags = tag_strings_by_movie.get(movie_id, ())
+            year = _extract_year(title)
+
+            all_genres.update(genres)
+            all_tags.update(tags)
+            raw_movies.append((movie_id, title, genres, year, tags))
+
+            if max_movies is not None and len(raw_movies) >= max_movies:
+                break
+
+    if not raw_movies:
+        raise ValueError(f"No movies were loaded from {movies_path}")
+
+    genre_to_value = {genre: idx + 1 for idx, genre in enumerate(sorted(all_genres))}
+    tag_to_value = {tag: idx + 1 for idx, tag in enumerate(sorted(all_tags))}
+
+    documents: list[MovieDocument] = []
+    for movie_id, title, genres, year, tags in raw_movies:
+        documents.append(
+            MovieDocument(
+                movie_id=movie_id,
+                title=title,
+                genres=tuple(genre_to_value[g] for g in genres),
+                year=year,
+                tags=tuple(tag_to_value[tag] for tag in tags if tag in tag_to_value),
+            )
+        )
+
+    has_tags = any(doc.tags for doc in documents)
+    feature_id_list = [FEATURE_GENRE, FEATURE_YEAR]
+    if has_tags:
+        feature_id_list.append(FEATURE_TAG)
+
+    values: list[int] = []
+    offsets = [0]
+    for _ in range(replication_factor):
+        for doc in documents:
+            values.extend(doc.genres)
+            offsets.append(len(values))
+
+            if doc.year is not None:
+                values.append(doc.year)
+            offsets.append(len(values))
+
+            if has_tags:
+                values.extend(doc.tags)
+                offsets.append(len(values))
+
+    return MovieLensCorpus(
+        feature_ids=torch.tensor(feature_id_list, dtype=torch.int32),
+        feature_offsets=torch.tensor(offsets, dtype=torch.long),
+        feature_values=torch.tensor(values, dtype=torch.long),
+        documents=documents,
+        num_docs=len(documents) * replication_factor,
+        base_num_docs=len(documents),
+        has_tags=has_tags,
+        genre_labels={value: genre for genre, value in genre_to_value.items()},
+        tag_labels={value: tag for tag, value in tag_to_value.items()},
+        all_genres=sorted(genre_to_value.values()),
+        all_years=sorted({doc.year for doc in documents if doc.year is not None}),
+        all_tags=sorted(tag_to_value.values()),
+    )

--- a/benchmark/movielens/movielens_32m.py
+++ b/benchmark/movielens/movielens_32m.py
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pyre-unsafe
+
+"""Fetch MovieLens 32M and run the SilverTorch smoke-test benchmark."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+FBCODE_ROOT = Path(__file__).resolve().parents[4]
+if __package__ in (None, ""):
+    if str(FBCODE_ROOT) not in sys.path:
+        sys.path.insert(0, str(FBCODE_ROOT))
+    __package__ = "silvertorch.silvertorch.benchmark.movielens"
+
+from .movielens_small import main as run_movielens_benchmark
+
+
+def main(argv: list[str] | None = None) -> None:
+    run_movielens_benchmark(argv, default_preset="32m")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/benchmark/movielens/movielens_small.py
+++ b/benchmark/movielens/movielens_small.py
@@ -1,0 +1,602 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pyre-unsafe
+
+"""Benchmark SilverTorch bloom-index ops on MovieLens metadata.
+
+This script uses the public MovieLens CSV datasets (for example
+``ml-latest-small`` or ``ml-latest``) and converts movie metadata into the
+feature tensor layout expected by SilverTorch:
+
+- feature id ``1``: movie genres (multi-value)
+- feature id ``2``: release year (single value when present)
+- feature id ``3``: normalized user tags from ``tags.csv`` (optional)
+
+The parser runs on CPU; build and search can run on CPU or CUDA.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import statistics
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast, TypeVar
+
+import silvertorch.ops._load_ops  # noqa: F401
+import torch
+
+SEED = 12345
+FBCODE_ROOT = Path(__file__).resolve().parents[4]
+if __package__ in (None, ""):
+    if str(FBCODE_ROOT) not in sys.path:
+        sys.path.insert(0, str(FBCODE_ROOT))
+    __package__ = "silvertorch.silvertorch.benchmark.movielens"
+
+from .dataloader import (
+    DATASET_URLS,
+    DEFAULT_DATA_ROOT,
+    FEATURE_GENRE,
+    FEATURE_TAG,
+    FEATURE_YEAR,
+    load_corpus,
+    MovieLensCorpus,
+    resolve_dataset_dir,
+)
+
+
+@dataclass(frozen=True)
+class QuerySpec:
+    expression: str
+    description: str
+
+
+@dataclass(frozen=True)
+class BenchmarkStats:
+    mean_ms: float
+    median_ms: float
+    min_ms: float
+
+
+@dataclass(frozen=True)
+class BenchmarkPreset:
+    dataset_name: str
+    replication_factor: int
+    include_tags: bool
+    num_queries: int
+    description: str
+
+
+PRESETS = {
+    "small": BenchmarkPreset(
+        dataset_name="ml-latest-small",
+        replication_factor=16,
+        include_tags=False,
+        num_queries=128,
+        description="MovieLens latest small benchmark preset.",
+    ),
+    "32m": BenchmarkPreset(
+        dataset_name="ml-32m",
+        replication_factor=1,
+        include_tags=False,
+        num_queries=256,
+        description="MovieLens 32M smoke-test and benchmark preset.",
+    ),
+}
+
+MeasureResult = TypeVar("MeasureResult")
+
+
+def _parse_args(
+    argv: list[str] | None = None,
+    *,
+    default_preset: str = "small",
+) -> argparse.Namespace:
+    preset = PRESETS[default_preset]
+    parser = argparse.ArgumentParser(
+        description=preset.description,
+    )
+    parser.add_argument(
+        "--dataset-dir",
+        type=Path,
+        default=None,
+        help="Path to an extracted MovieLens CSV dataset directory.",
+    )
+    parser.add_argument(
+        "--dataset-name",
+        choices=sorted(DATASET_URLS),
+        default=preset.dataset_name,
+        help="Dataset to download into benchmark/data when --download is used.",
+    )
+    parser.add_argument(
+        "--data-root",
+        type=Path,
+        default=DEFAULT_DATA_ROOT,
+        help="Root directory for downloaded datasets.",
+    )
+    parser.add_argument(
+        "--download",
+        action="store_true",
+        help="Download the dataset if it is missing.",
+    )
+    parser.add_argument(
+        "--device",
+        choices=["auto", "cpu", "cuda"],
+        default="auto",
+        help="Where to run build/search. The parser always runs on CPU.",
+    )
+    parser.add_argument(
+        "--replication-factor",
+        type=int,
+        default=preset.replication_factor,
+        help="Repeat the base MovieLens corpus N times to scale the benchmark.",
+    )
+    parser.add_argument(
+        "--max-movies",
+        type=int,
+        default=None,
+        help="Cap the number of base movies loaded before replication.",
+    )
+    parser.add_argument(
+        "--include-tags",
+        action="store_true",
+        default=preset.include_tags,
+        help="Include normalized tags from tags.csv as a third feature.",
+    )
+    parser.add_argument(
+        "--no-include-tags",
+        action="store_false",
+        dest="include_tags",
+        help="Disable tag loading even if the preset enables it.",
+    )
+    parser.add_argument(
+        "--min-tag-frequency",
+        type=int,
+        default=2,
+        help="Only keep normalized tags seen at least this many times globally.",
+    )
+    parser.add_argument(
+        "--max-tags-per-movie",
+        type=int,
+        default=3,
+        help="Cap the number of kept tags per movie.",
+    )
+    parser.add_argument("--k", type=int, default=3, help="Bloom index K.")
+    parser.add_argument(
+        "--hash-k",
+        type=int,
+        default=7,
+        help="Parser/search HASH_K. Must be >= --k.",
+    )
+    parser.add_argument(
+        "--b-multiplier",
+        type=float,
+        default=5.0,
+        help="Bloom width multiplier passed to bloom_index_build.",
+    )
+    parser.add_argument(
+        "--num-queries",
+        type=int,
+        default=preset.num_queries,
+        help="Number of benchmark queries in the search batch.",
+    )
+    parser.add_argument(
+        "--warmup-iters",
+        type=int,
+        default=5,
+        help="Number of warmup iterations per benchmark stage.",
+    )
+    parser.add_argument(
+        "--iters",
+        type=int,
+        default=20,
+        help="Number of measured iterations per benchmark stage.",
+    )
+    parser.add_argument(
+        "--sample-queries",
+        type=int,
+        default=5,
+        help="How many sample queries to print with hit counts.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=SEED,
+        help="Random seed for query generation.",
+    )
+    return parser.parse_args(argv)
+
+
+def _choose_device(device_arg: str) -> str:
+    if device_arg == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if device_arg == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA requested but torch.cuda.is_available() is False")
+    return device_arg
+
+
+def _sync_for_device(device: str) -> None:
+    if device == "cuda":
+        torch.cuda.synchronize()
+
+
+def _measure(
+    fn: Callable[[], MeasureResult],
+    *,
+    device: str,
+    warmup_iters: int,
+    iters: int,
+) -> tuple[BenchmarkStats, MeasureResult]:
+    result: MeasureResult | None = None
+    for _ in range(warmup_iters):
+        result = fn()
+        _sync_for_device(device)
+
+    timings_s = []
+    for _ in range(iters):
+        _sync_for_device(device)
+        start = time.perf_counter()
+        result = fn()
+        _sync_for_device(device)
+        timings_s.append(time.perf_counter() - start)
+
+    timings_ms = [value * 1000.0 for value in timings_s]
+    stats = BenchmarkStats(
+        mean_ms=statistics.mean(timings_ms),
+        median_ms=statistics.median(timings_ms),
+        min_ms=min(timings_ms),
+    )
+    if result is None:
+        raise RuntimeError("Benchmark did not execute any iterations")
+    return stats, result
+
+
+def _generate_query_specs(
+    corpus: MovieLensCorpus,
+    num_queries: int,
+    *,
+    seed: int,
+) -> list[QuerySpec]:
+    rng = random.Random(seed)
+    docs_with_year = [doc for doc in corpus.documents if doc.year is not None]
+    docs_with_tags = [doc for doc in corpus.documents if doc.tags]
+    docs_with_multi_genre = [doc for doc in corpus.documents if len(doc.genres) >= 2]
+
+    if not corpus.documents:
+        raise ValueError("No documents available for query generation")
+    if not corpus.all_genres:
+        raise ValueError("MovieLens corpus has no genres to query")
+
+    queries: list[QuerySpec] = []
+    while len(queries) < num_queries:
+        choice = rng.choice(
+            ["genre", "genre_and_year", "genre_or_genre", "genre_not", "tag_and_genre"]
+        )
+
+        if choice == "genre":
+            doc = rng.choice(corpus.documents)
+            if not doc.genres:
+                continue
+            genre = rng.choice(doc.genres)
+            label = corpus.genre_labels[genre]
+            queries.append(QuerySpec(f"{FEATURE_GENRE}:{genre}", f"genre={label}"))
+            continue
+
+        if choice == "genre_and_year":
+            if not docs_with_year:
+                continue
+            doc = rng.choice(docs_with_year)
+            if not doc.genres:
+                continue
+            genre = rng.choice(doc.genres)
+            label = corpus.genre_labels[genre]
+            queries.append(
+                QuerySpec(
+                    f"{FEATURE_GENRE}:{genre} AND {FEATURE_YEAR}:{doc.year}",
+                    f"genre={label} AND year={doc.year}",
+                )
+            )
+            continue
+
+        if choice == "genre_or_genre":
+            if docs_with_multi_genre:
+                doc = rng.choice(docs_with_multi_genre)
+                genre_a, genre_b = rng.sample(list(doc.genres), k=2)
+            else:
+                doc = rng.choice(corpus.documents)
+                if not doc.genres:
+                    continue
+                genre_a = rng.choice(doc.genres)
+                other_choices = [g for g in corpus.all_genres if g != genre_a]
+                if not other_choices:
+                    continue
+                genre_b = rng.choice(other_choices)
+
+            if doc.year is not None:
+                queries.append(
+                    QuerySpec(
+                        (
+                            f"({FEATURE_GENRE}:{genre_a} OR {FEATURE_GENRE}:{genre_b}) "
+                            f"AND {FEATURE_YEAR}:{doc.year}"
+                        ),
+                        (
+                            f"(genre={corpus.genre_labels[genre_a]} OR "
+                            f"genre={corpus.genre_labels[genre_b]}) AND year={doc.year}"
+                        ),
+                    )
+                )
+            else:
+                queries.append(
+                    QuerySpec(
+                        f"{FEATURE_GENRE}:{genre_a} OR {FEATURE_GENRE}:{genre_b}",
+                        (
+                            f"genre={corpus.genre_labels[genre_a]} OR "
+                            f"genre={corpus.genre_labels[genre_b]}"
+                        ),
+                    )
+                )
+            continue
+
+        if choice == "genre_not":
+            doc = rng.choice(corpus.documents)
+            if not doc.genres:
+                continue
+            genre = rng.choice(doc.genres)
+            excluded_choices = [g for g in corpus.all_genres if g not in doc.genres]
+            if not excluded_choices:
+                continue
+            excluded = rng.choice(excluded_choices)
+            queries.append(
+                QuerySpec(
+                    f"{FEATURE_GENRE}:{genre} AND NOT {FEATURE_GENRE}:{excluded}",
+                    (
+                        f"genre={corpus.genre_labels[genre]} AND NOT "
+                        f"genre={corpus.genre_labels[excluded]}"
+                    ),
+                )
+            )
+            continue
+
+        if choice == "tag_and_genre":
+            if not corpus.has_tags or not docs_with_tags:
+                continue
+            doc = rng.choice(docs_with_tags)
+            if not doc.genres:
+                continue
+            tag = rng.choice(doc.tags)
+            genre = rng.choice(doc.genres)
+            queries.append(
+                QuerySpec(
+                    f"{FEATURE_TAG}:{tag} AND {FEATURE_GENRE}:{genre}",
+                    (
+                        f"tag={corpus.tag_labels[tag]} AND "
+                        f"genre={corpus.genre_labels[genre]}"
+                    ),
+                )
+            )
+
+    if not queries:
+        raise ValueError("No queries generated")
+    return queries
+
+
+def _size_mb(tensor: torch.Tensor) -> float:
+    return tensor.numel() * tensor.element_size() / (1024.0 * 1024.0)
+
+
+def _print_summary(
+    dataset_dir: Path,
+    device: str,
+    corpus: MovieLensCorpus,
+    build_stats: BenchmarkStats,
+    parse_stats: BenchmarkStats,
+    search_stats: BenchmarkStats,
+    bloom_index: torch.Tensor,
+    plans_data: torch.Tensor,
+    queries: list[QuerySpec],
+    result_mask: torch.Tensor,
+    sample_queries: int,
+) -> None:
+    print("=" * 72)
+    print("SILVERTORCH MOVIELENS BENCHMARK")
+    print("=" * 72)
+    print(f"Dataset:          {dataset_dir}")
+    print(f"Device:           {device}")
+    print(f"Base movies:      {corpus.base_num_docs}")
+    print(f"Indexed docs:     {corpus.num_docs}")
+    print(f"Features/doc:     {corpus.feature_ids.numel()}")
+    print(f"Tag feature:      {'enabled' if corpus.has_tags else 'disabled'}")
+    print(f"Genre values:     {len(corpus.genre_labels)}")
+    print(f"Year values:      {len(corpus.all_years)}")
+    print(f"Tag values:       {len(corpus.tag_labels)}")
+    print(
+        f"Index size:       {bloom_index.numel()} int64s ({_size_mb(bloom_index):.2f} MB)"
+    )
+    print(
+        f"Plan size:        {plans_data.numel()} int64s ({_size_mb(plans_data):.2f} MB)"
+    )
+    print()
+    print("Timing (mean / median / min)")
+    print(
+        f"  Build:          {build_stats.mean_ms:.2f} / {build_stats.median_ms:.2f} / {build_stats.min_ms:.2f} ms"
+    )
+    print(
+        f"  Parse:          {parse_stats.mean_ms:.2f} / {parse_stats.median_ms:.2f} / {parse_stats.min_ms:.2f} ms"
+    )
+    print(
+        f"  Search batch:   {search_stats.mean_ms:.2f} / {search_stats.median_ms:.2f} / {search_stats.min_ms:.2f} ms"
+    )
+    print()
+    print("Sample queries")
+    visible_docs = result_mask[:, : corpus.num_docs]
+    for idx, query in enumerate(queries[:sample_queries]):
+        hit_count = int(visible_docs[idx].sum().item())
+        print(f"  {idx + 1}. {query.description}")
+        print(f"     expr={query.expression}")
+        print(f"     hits={hit_count}")
+
+
+def _run_smoke_checks(
+    corpus: MovieLensCorpus,
+    queries: list[QuerySpec],
+    bloom_index: torch.Tensor,
+    result_mask: torch.Tensor,
+) -> None:
+    if not hasattr(torch.ops, "st") or not hasattr(torch.ops.st, "bloom_index_build"):
+        raise RuntimeError("torch.ops.st.bloom_index_build is not registered")
+    if not hasattr(torch.ops.st, "bloom_index_search_batch"):
+        raise RuntimeError("torch.ops.st.bloom_index_search_batch is not registered")
+    if bloom_index.numel() == 0:
+        raise RuntimeError("bloom_index_build returned an empty index")
+
+    visible_docs = result_mask[:, : corpus.num_docs]
+    if visible_docs.size(0) != len(queries):
+        raise RuntimeError(
+            f"search result batch size {visible_docs.size(0)} did not match {len(queries)} queries"
+        )
+    if visible_docs.size(1) != corpus.num_docs:
+        raise RuntimeError(
+            f"search result width {visible_docs.size(1)} did not match {corpus.num_docs} indexed docs"
+        )
+    if not bool(visible_docs.any(dim=1).all().item()):
+        raise RuntimeError(
+            "at least one generated query returned zero hits; package smoke test failed"
+        )
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    default_preset: str = "small",
+) -> None:
+    args = _parse_args(argv, default_preset=default_preset)
+    if args.hash_k < args.k:
+        raise ValueError("--hash-k must be >= --k")
+
+    dataset_dir = resolve_dataset_dir(
+        dataset_dir=args.dataset_dir,
+        data_root=args.data_root,
+        dataset_name=args.dataset_name,
+        download=args.download,
+    )
+    device = _choose_device(args.device)
+
+    corpus = load_corpus(
+        dataset_dir=dataset_dir,
+        include_tags=args.include_tags,
+        min_tag_frequency=args.min_tag_frequency,
+        max_tags_per_movie=args.max_tags_per_movie,
+        max_movies=args.max_movies,
+        replication_factor=args.replication_factor,
+    )
+    queries = _generate_query_specs(
+        corpus,
+        args.num_queries,
+        seed=args.seed,
+    )
+
+    feature_ids = corpus.feature_ids.to(device)
+    feature_offsets = corpus.feature_offsets.to(device)
+    feature_values = corpus.feature_values.to(device)
+    silvertorch_ks = torch.full((len(queries),), args.k, dtype=torch.long)
+    expressions = [query.expression for query in queries]
+
+    build_fn: Callable[[], tuple[torch.Tensor, torch.Tensor]] = lambda: cast(
+        tuple[torch.Tensor, torch.Tensor],
+        torch.ops.st.bloom_index_build(
+            feature_ids,
+            feature_offsets,
+            feature_values,
+            args.b_multiplier,
+            args.k,
+        ),
+    )
+    build_stats, build_result = _measure(
+        build_fn,
+        device=device,
+        warmup_iters=args.warmup_iters,
+        iters=args.iters,
+    )
+    bloom_index, bundle_b_offsets = build_result
+
+    parse_fn: Callable[[], tuple[object, tuple[torch.Tensor, torch.Tensor]]] = (
+        lambda: cast(
+            tuple[object, tuple[torch.Tensor, torch.Tensor]],
+            torch.ops.st.parse_expression_query_batch(
+                expressions,
+                silvertorch_ks,
+                args.hash_k,
+                True,
+                8,
+            ),
+        )
+    )
+    parse_stats, parse_result = _measure(
+        parse_fn,
+        device="cpu",
+        warmup_iters=args.warmup_iters,
+        iters=args.iters,
+    )
+    _, tensors = parse_result
+    plans_data, plans_offsets = tensors
+
+    if device == "cuda":
+        plans_data = plans_data.cuda()
+        plans_offsets = plans_offsets.cuda()
+
+    search_fn: Callable[[], torch.Tensor] = lambda: cast(  # noqa: E731
+        torch.Tensor,
+        torch.ops.st.bloom_index_search_batch(
+            bloom_index,
+            bundle_b_offsets,
+            plans_data,
+            plans_offsets,
+            args.k,
+            args.hash_k,
+            True,
+        ),
+    )
+    search_stats, search_result = _measure(
+        search_fn,
+        device=device,
+        warmup_iters=args.warmup_iters,
+        iters=args.iters,
+    )
+
+    result_mask = (
+        search_result.cpu() if search_result.device.type == "cuda" else search_result
+    )
+    _run_smoke_checks(corpus, queries, bloom_index, result_mask)
+    _print_summary(
+        dataset_dir=dataset_dir,
+        device=device,
+        corpus=corpus,
+        build_stats=build_stats,
+        parse_stats=parse_stats,
+        search_stats=search_stats,
+        bloom_index=bloom_index,
+        plans_data=plans_data,
+        queries=queries,
+        result_mask=result_mask,
+        sample_queries=args.sample_queries,
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Summary:
Add a shared benchmark/movielens/dataloader.py module for fetching and loading MovieLens datasets into the SilverTorch tensor layout.

Refactor movielens_small.py to use the shared loader and keep benchmarking and smoke-test logic in one place. Add movielens_32m.py as a thin preset wrapper for the 32M dataset so the larger benchmark path stays minimal and easy to invoke.

### Example run on B200 GPU

#### small dataset
```
python benchmark/movielens/movielens_small.py --download --device cuda

========================================================================
SILVERTORCH MOVIELENS BENCHMARK
========================================================================
Dataset:          /home/jiazhouwang/code/silvertorch/benchmark/data/ml-latest-small
Device:           cuda
Base movies:      9742
Indexed docs:     155872
Features/doc:     2
Tag feature:      disabled
Genre values:     19
Year values:      106
Tag values:       0
Index size:       318240 int64s (2.43 MB)
Plan size:        19704 int64s (0.02 MB)

Timing (mean / median / min)
  Build:          0.24 / 0.23 / 0.23 ms
  Parse:          0.34 / 0.34 / 0.33 ms
  Search batch:   1.38 / 1.38 / 1.37 ms

Sample queries
  1. genre=Sci-Fi AND NOT genre=Musical
     expr=1:16 AND NOT 1:13
     hits=15552
  2. genre=Fantasy AND year=2003
     expr=1:9 AND 2:2003
     hits=291
  3. genre=Action AND year=2006
     expr=1:1 AND 2:2006
     hits=784
  4. genre=Drama AND NOT genre=Western
     expr=1:8 AND NOT 1:19
     hits=68794
  5. genre=Horror AND year=2005
     expr=1:11 AND 2:2005
     hits=576
```

#### 32M dataset
```
python benchmark/movielens/movielens_32m.py --download --device cuda

========================================================================
SILVERTORCH MOVIELENS BENCHMARK
========================================================================
Dataset:          /home/jiazhouwang/code/silvertorch/benchmark/data/ml-32m
Device:           cuda
Base movies:      87585
Indexed docs:     87585
Features/doc:     2
Tag feature:      disabled
Genre values:     19
Year values:      142
Tag values:       0
Index size:       155040 int64s (1.18 MB)
Plan size:        39736 int64s (0.04 MB)

Timing (mean / median / min)
  Build:          0.19 / 0.19 / 0.18 ms
  Parse:          1.19 / 1.19 / 1.15 ms
  Search batch:   3.84 / 3.84 / 3.82 ms

Sample queries
  1. genre=Drama AND NOT genre=Musical
     expr=1:8 AND NOT 1:13
     hits=33835
  2. genre=Crime AND year=1983
     expr=1:6 AND 2:1983
     hits=46
  3. genre=Comedy AND year=2014
     expr=1:5 AND 2:2014
     hits=748
  4. genre=Crime AND NOT genre=Documentary
     expr=1:6 AND NOT 1:7
     hits=6860
  5. (genre=Drama OR genre=Comedy) AND year=2004
     expr=(1:8 OR 1:5) AND 2:2004
     hits=921
```


Reviewed By: uciyc123

Differential Revision: D104429416

Pulled By: guabao


